### PR TITLE
Fix a simple typo from portuguese to English on errors

### DIFF
--- a/liasis/core/errors/__init__.py
+++ b/liasis/core/errors/__init__.py
@@ -6,7 +6,7 @@ class Error(Exception):
         self.message = message
     
     def __str__(self):
-        return f"{self.title}: {self.message} Código:{self.code}"
+        return f"{self.title}: {self.message} Code:{self.code}"
 
 
 from .domain import *


### PR DESCRIPTION
on file ./liasis/core/errors/__init__.py has a error with text in
portuguese and this project is english.

Resolve: #6

@johnnywell 